### PR TITLE
Update Laboratorio 3.ipynb

### DIFF
--- a/CNYT/Laboratorios/Laboratorio 3/Laboratorio 3.ipynb
+++ b/CNYT/Laboratorios/Laboratorio 3/Laboratorio 3.ipynb
@@ -620,7 +620,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![./CNYT/ESTADOS.PNG](./CNYT/ESTADOS.PNG)"
+    "![./CNYT/ESTADOS.PNG](./CNYT/ESTADOS.png)"
    ]
   },
   {
@@ -635,7 +635,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![./CNYT/GRAFO.PNG](./CNYT/GRAFO.PNG)"
+    "![./CNYT/GRAFO.PNG](./CNYT/GRAFO.png)"
    ]
   },
   {
@@ -650,7 +650,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![./CNYT/MATRIZ.PNG](./CNYT/MATRIZ.PNG)"
+    "![./CNYT/MATRIZ.PNG](./CNYT/MATRIZ.png)"
    ]
   },
   {


### PR DESCRIPTION
Las imágenes en Markdown están nombradas ".png", en minúsculas.